### PR TITLE
Add XOrg to Debian/Ubuntu rootfs.

### DIFF
--- a/res/opensysroot/opensysroot/__init__.py
+++ b/res/opensysroot/opensysroot/__init__.py
@@ -52,6 +52,7 @@ def main():
         assert args.arch is not Arch.CORTEXA9
         db.add_package("gcc")
         db.add_package("g++")
+        db.add_package("xorg-dev")
         if args.minimal_toolchain:
             raise RuntimeError("Minimal toolchain flag is unsupported for Debian targets")
 

--- a/res/opensysroot/opensysroot/__init__.py
+++ b/res/opensysroot/opensysroot/__init__.py
@@ -52,7 +52,15 @@ def main():
         assert args.arch is not Arch.CORTEXA9
         db.add_package("gcc")
         db.add_package("g++")
-        db.add_package("xorg-dev")
+
+        # Packages for GLFW
+        db.add_package("libx11-dev")
+        db.add_package("libxcursor-dev")
+        db.add_package("libxrandr-dev")
+        db.add_package("libxinerama-dev")
+        db.add_package("libxi-dev")
+        db.add_package("mesa-common-dev")
+
         if args.minimal_toolchain:
             raise RuntimeError("Minimal toolchain flag is unsupported for Debian targets")
 

--- a/res/opensysroot/opensysroot/workenvironment.py
+++ b/res/opensysroot/opensysroot/workenvironment.py
@@ -87,6 +87,8 @@ class WorkEnvironment:
         for file in self.sysroot.glob("**/*"):
             if not file.is_symlink():
                 continue
+            if "usr/bin" in str(file):
+                continue
             resolved = Path(os.readlink(file))
             if resolved.is_absolute():
                 resolved = Path("{}/{}".format(self.sysroot, resolved))
@@ -95,7 +97,9 @@ class WorkEnvironment:
                     "{}/{}".format(file.parent.absolute(), resolved))
             resolved = resolved.resolve()
             file.unlink()
-            if resolved.exists():
+            if resolved.is_dir():
+                shutil.copytree(resolved, file)
+            elif resolved.exists():
                 shutil.copy2(resolved, file)
 
     def get_orig_tuple(self):


### PR DESCRIPTION
Ideally, one would use the multi-arch capability of Debian to build with the Debian tooling, but WPILib does not use Debian, so this has to be added to the toolchain. This will affect both Debian and Ubuntu targets.

Closes #33.