### PR TITLE
Remove references to a toolchain rebuilds

### DIFF
--- a/makes/src/13-normalize.sh
+++ b/makes/src/13-normalize.sh
@@ -65,22 +65,3 @@ else
     rm -rf usr/lib/mime
     rm -rf usr/lib/tar
 fi
-
-if [ "${TARGET_LIB_REBUILD}" = "true" ]; then
-    # Delete libstdc++ headers which will be replaced
-    rm -rf usr/include/c++/
-
-    # Delete GCC runtime artifacts
-    if [ "${TARGET_DISTRO}" = "roborio" ] ||
-        [ "${TARGET_DISTRO}" = "roborio-academic" ]; then
-        rm -rf usr/lib/gcc/
-        rm -rf usr/lib/libgcc_s.so*
-        rm -rf usr/lib/libatomic.so*
-        rm -rf usr/lib/libstdc++.so*
-    else
-        rm -rf usr/lib/"${TARGET_TUPLE}"/gcc/
-        rm -rf usr/lib/"${TARGET_TUPLE}"/libgcc_s.so*
-        rm -rf usr/lib/"${TARGET_TUPLE}"/libatomic.so*
-        rm -rf usr/lib/"${TARGET_TUPLE}"/libstdc++.so*
-    fi
-fi

--- a/makes/src/42-gcc-libraries.sh
+++ b/makes/src/42-gcc-libraries.sh
@@ -45,13 +45,3 @@ if [ -d "${BUILD_DIR}/gcc-install/tmp/frc/${TARGET_TUPLE}/lib" ]; then
         "${BUILD_DIR}/gcc-install/tmp/frc/${TARGET_TUPLE}/sysroot/usr/lib/"
     rm -rf "${BUILD_DIR}/gcc-install/tmp/frc/${TARGET_TUPLE}/lib"
 fi
-
-if [ "${TARGET_LIB_REBUILD}" = "true" ]; then
-    # Duplicate the GCC runtime artifacts to a seperate directory
-    # so it can later be scp'd to the roboRIO.
-    rsync -aEL \
-        "${BUILD_DIR}/gcc-install/tmp/frc/${TARGET_TUPLE}/sysroot/usr/lib/" \
-        "${BUILD_DIR}/gcc-install/tmp/frc/${TARGET_TUPLE}/gcclib/"
-    # We don't need the static libraries of the GCC runtime
-    rm -r "${BUILD_DIR}/gcc-install/tmp/frc/${TARGET_TUPLE}/gcclib/gcc"
-fi

--- a/makes/src/98-package-backend.sh
+++ b/makes/src/98-package-backend.sh
@@ -23,25 +23,11 @@ source "$(dirname "$0")/common.sh"
 rm -rf backend-install
 mkdir -p backend-install/tmp/frc
 
-if [ "$TARGET_LIB_REBUILD" = "true" ]; then
-    # Hack to make the linker behave nicely with a out of tree libgcc.
-    # This will take double the space on disk but is compressed
-    # within the zip/tgz file.
-    # TODO: Remove artifact from the old GCC build to cut down on space.
-    rsync -aEL \
-        "gcc-install/tmp/frc/${TARGET_TUPLE}/gcclib/" \
-        "gcc-install/tmp/frc/${TARGET_TUPLE}/sysroot/usr/lib/"
-fi
-
 # Build backend archive for use by the frontend builds.
 rsync -aEL \
     "sysroot-install/" \
     "backend-install/"
-if [ "$TARGET_LIB_REBUILD" = "true" ]; then
-    rsync -aEL \
-        "gcc-install/tmp/frc/${TARGET_TUPLE}/gcclib" \
-        "backend-install/${TARGET_TUPLE}/"
-fi
+
 if is_lib_rebuild_required; then
     rsync -aEL \
         "gcc-install/tmp/frc/${TARGET_TUPLE}/sysroot" \

--- a/makes/src/utils/funcs.sh
+++ b/makes/src/utils/funcs.sh
@@ -91,12 +91,16 @@ configure_target_vars() {
 gcc_update_target_list() {
     env_exists SYSROOT_BUILD_PATH
     gcc_need_lib_build() {
-        local lib1="${SYSROOT_BUILD_PATH}/usr/lib/$1"
-        local lib2="${SYSROOT_BUILD_PATH}/usr/lib/gcc/${TARGET_TUPLE}/${V_GCC/.*/}/$1"
-        if [ "$TARGET_LIB_REBUILD" = "true" ]; then
-            return 0
+        local lib
+
+        if [ "${TARGET_DISTRO}" = "roborio" ] ||
+            [ "${TARGET_DISTRO}" = "roborio-academic" ]; then
+            lib="${SYSROOT_BUILD_PATH}/usr/lib/$1"
+        else
+            lib="${SYSROOT_BUILD_PATH}/usr/lib/gcc/${TARGET_TUPLE}/${V_GCC/.*/}/$1"
         fi
-        if (compgen -G "${lib1}.so*" || compgen -G "${lib2}.so*") >/dev/null; then
+
+        if compgen -G "${lib}.so*" >/dev/null; then
             return 1
         fi
         return 0

--- a/res/opensysroot/opensysroot/__init__.py
+++ b/res/opensysroot/opensysroot/__init__.py
@@ -21,8 +21,6 @@ def arg_info():
     parser.add_argument("output", type=Path, default=Path("build"))
     parser.add_argument("--print-dest-sysroot",
                         default=False, action='store_true')
-    parser.add_argument("--minimal-toolchain",
-                        default=False, action='store_true')
     return parser.parse_args()
 
 
@@ -36,22 +34,20 @@ def main():
         args.distro, args.arch, args.release)
 
     env = WorkEnvironment(args.distro, args.arch, args.release,
-                          args.output, args.print_dest_sysroot,
-                          args.minimal_toolchain)
+                          args.output, args.print_dest_sysroot)
 
     db = Database(repo_packages_url)
     if args.distro in (Distro.ROBORIO_STD, Distro.ROBORIO_ACADEMIC):
         assert args.arch is Arch.CORTEXA9
         db.add_package("libc6-dev")
         db.add_package("linux-libc-headers-dev")
-        if not args.minimal_toolchain:
-            db.add_package("gcc-dev")
-            db.add_package("libstdc++-dev")
-            db.add_package("libatomic-dev")
-            # debug symbols for remote debugging
-            db.add_package("libc6-dbg")
-            db.add_package("libgcc-s-dbg")
-            db.add_package("gcc-runtime-dbg")
+        db.add_package("gcc-dev")
+        db.add_package("libstdc++-dev")
+        db.add_package("libatomic-dev")
+        # debug symbols for remote debugging
+        db.add_package("libc6-dbg")
+        db.add_package("libgcc-s-dbg")
+        db.add_package("gcc-runtime-dbg")
     else:
         assert args.arch is not Arch.CORTEXA9
         db.add_package("gcc")
@@ -64,9 +60,6 @@ def main():
         db.add_package("libxinerama-dev")
         db.add_package("libxi-dev")
         db.add_package("mesa-common-dev")
-
-        if args.minimal_toolchain:
-            raise RuntimeError("Minimal toolchain flag is unsupported for Debian targets")
 
     db.post_resolve()
     db.download(repo_url, env.downloads)

--- a/res/opensysroot/opensysroot/workenvironment.py
+++ b/res/opensysroot/opensysroot/workenvironment.py
@@ -32,18 +32,18 @@ ROBORIO_TO_RENAME = [
     "usr/lib/gcc/{tuple}/{ver}",
 ]
 
+
 class WorkEnvironment:
     base: Path
     sysroot: Path
     downloads: Path
 
-    def __init__(self, distro: Distro, arch: Arch, release: Release, workdir: Path, print_dest_sysroot: bool, minimal_toolchain: bool):
+    def __init__(self, distro: Distro, arch: Arch, release: Release, workdir: Path, print_dest_sysroot: bool):
         self.arch = arch
         self.distro = distro
         self.base = Path(workdir, str(distro), str(release), str(arch))
         self.sysroot = Path(self.base, "sysroot")
         self.downloads = Path(self.base, "downloads")
-        self.minimal = minimal_toolchain
 
         if print_dest_sysroot:
             print(self.sysroot.resolve())
@@ -62,7 +62,7 @@ class WorkEnvironment:
     def clean(self):
         self._symlink()
         self._delete()
-        if self.distro is Distro.ROBORIO_STD and not self.minimal:
+        if self.distro is Distro.ROBORIO_STD:
             self._major_only()
 
     def _major_only(self):


### PR DESCRIPTION
We are mostly building sysroots from distro repositories. The feature being removed was never used in production and is no longer needed.